### PR TITLE
Use RelWithDebInfo and nostrip

### DIFF
--- a/bloom/generators/debian/templates/rules.em
+++ b/bloom/generators/debian/templates/rules.em
@@ -18,6 +18,7 @@ export PKG_CONFIG_PATH=@(InstallationPrefix)/lib/pkgconfig
 # Explicitly enable -DNDEBUG, see:
 # 	https://github.com/ros-infrastructure/bloom/issues/327
 export DEB_CXXFLAGS_MAINT_APPEND=-DNDEBUG
+export DEB_BUILD_OPTIONS=nostrip
 
 %:
 	dh  $@@
@@ -30,7 +31,8 @@ override_dh_auto_configure:
 	dh_auto_configure -- \
 		-DCATKIN_BUILD_BINARY_PACKAGE="1" \
 		-DCMAKE_INSTALL_PREFIX="@(InstallationPrefix)" \
-		-DCMAKE_PREFIX_PATH="@(InstallationPrefix)"
+		-DCMAKE_PREFIX_PATH="@(InstallationPrefix)" \
+		-DCMAKE_BUILD_TYPE="RelWithDebInfo"
 
 override_dh_auto_build:
 	# In case we're installing to a non-standard location, look for a setup.sh


### PR DESCRIPTION
FYI @locusrobotics/robot-software-team 

Installing this via:

`sudo pip install git+https://github.com/locusrobotics/bloom.git@locus-master --force-reinstall --upgrade`

should update all future blooms to include debug symbols in builds.