### PR TITLE
Putting O3 flag in default

### DIFF
--- a/bloom/generators/debian/templates/rules.em
+++ b/bloom/generators/debian/templates/rules.em
@@ -17,7 +17,7 @@ export LDFLAGS=
 export PKG_CONFIG_PATH=@(InstallationPrefix)/lib/pkgconfig
 # Explicitly enable -DNDEBUG, see:
 # 	https://github.com/ros-infrastructure/bloom/issues/327
-export DEB_CXXFLAGS_MAINT_APPEND=-DNDEBUG
+export DEB_CXXFLAGS_MAINT_APPEND=-DNDEBUG -O3
 export DEB_BUILD_OPTIONS=nostrip
 
 %:


### PR DESCRIPTION
I originally did this to try to force the patching step to not see this patch as being required. However, that didn't work, and I found a better way to handle it. In the meantime, we've had packages released with this setting, and it can't hurt to keep it.