### PR TITLE
Removing RelWithDebInfo flag, adding manual -g

### DIFF
--- a/bloom/generators/debian/templates/catkin/rules.em
+++ b/bloom/generators/debian/templates/catkin/rules.em
@@ -16,7 +16,7 @@ export LDFLAGS=
 export PKG_CONFIG_PATH=@(InstallationPrefix)/lib/pkgconfig
 # Explicitly enable -DNDEBUG, see:
 # 	https://github.com/ros-infrastructure/bloom/issues/327
-export DEB_CXXFLAGS_MAINT_APPEND=-DNDEBUG -O3
+export DEB_CXXFLAGS_MAINT_APPEND=-DNDEBUG -O3 -g
 export DEB_BUILD_OPTIONS=nostrip
 
 %:
@@ -30,8 +30,7 @@ override_dh_auto_configure:
 	dh_auto_configure -- \
 		-DCATKIN_BUILD_BINARY_PACKAGE="1" \
 		-DCMAKE_INSTALL_PREFIX="@(InstallationPrefix)" \
-		-DCMAKE_PREFIX_PATH="@(InstallationPrefix)" \
-		-DCMAKE_BUILD_TYPE="RelWithDebInfo"
+		-DCMAKE_PREFIX_PATH="@(InstallationPrefix)"
 
 override_dh_auto_build:
 	# In case we're installing to a non-standard location, look for a setup.sh


### PR DESCRIPTION
The old setting was causing our `-O3` override to get overridden by `-O2` on the build farm.